### PR TITLE
Separate labels from keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,10 @@ plugin {
     #windows are restored to fullscreen after easymotion is exited/selected
     fullscreen_action=none
 
-    #which keys to use for labeling windows
+    #which keys to use for selecting windows
     motionkeys=abcdefghijklmnopqrstuvwxyz1234567890
+    #which keys to use for labeling windows
+    motionlabels=ABCDEFGHIJKLMNOPQRSTUVWXYZ1234567890
 
     #if a monitor has a focused special workspace, only put easymotion labels on the windows in the special workspace
     only_special = true

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ plugin {
 
     #what to do if a window is fullscreen
     #none: nothing. (easymotion label won't be displayed on that window)
-    #toggle: take the window out of fullscreen entirely. 
+    #toggle: take the window out of fullscreen entirely.
     #maximize: convert the window to maximized.
     #windows are restored to fullscreen after easymotion is exited/selected
     fullscreen_action=none
@@ -85,7 +85,7 @@ Please note, you should *also have hyprland as a flake input*.
 Add this repo to your flake inputs:
 ```nix
 inputs = {
-  hyprland.url = "git+https://github.com/hyprwm/Hyprland?submodules=1";
+  hyprland.url = "github:hyprwm/Hyprland";
 
   hyprland-easymotion = {
     url = "github:zakk4223/hyprland-easymotion";
@@ -93,7 +93,7 @@ inputs = {
   };
   # ...
 };
-outputs = { self, hyprland, ... } @ inputs:
+outputs = { self, hyprland, hyprland-easymotion, ... } @ inputs:
   # ...
 ```
 Add the plugin to your Hyprland Home Manager config:

--- a/easymotionDeco.cpp
+++ b/easymotionDeco.cpp
@@ -126,34 +126,25 @@ void CHyprEasyLabel::draw(PHLMONITOR pMonitor, float const &a) {
 		return;
 
 	const auto PWINDOW = m_pWindow.lock();
-
 	if (!PWINDOW->m_windowData.decorate.valueOrDefault())
 		return;
-
 	const auto PWORKSPACE      = PWINDOW->m_workspace;
 	const auto WORKSPACEOFFSET = PWORKSPACE && !PWINDOW->m_pinned ? PWORKSPACE->m_renderOffset->value() : Vector2D();
-
 	const auto DECOBOX = assignedBoxGlobal();
-
 	const auto BARBUF = DECOBOX.size() * pMonitor->m_scale;
-
 	//CBox       motionBox = {DECOBOX.x - pMonitor->vecPosition.x, DECOBOX.y - pMonitor->vecPosition.y, DECOBOX.w,
 	
 	auto TEXTBUF = DECOBOX.size();
 
-
 	if (!m_tTextTex.get()) {
 		renderMotionString(TEXTBUF, pMonitor->m_scale);
 	}
-
 	CBox       motionBox = {DECOBOX.x, DECOBOX.y, m_tTextTex->m_size.x, m_tTextTex->m_size.y};
 	motionBox.translate(pMonitor->m_position*-1).scale(pMonitor->m_scale).round();
-
 	if (motionBox.w < 1 || motionBox.h < 1)
 	{
 		return;
 	}
-
 	CRectPassElement::SRectData rectData;
 	rectData.color = m_cBackgroundColor;
 	rectData.box = motionBox;
@@ -166,9 +157,9 @@ void CHyprEasyLabel::draw(PHLMONITOR pMonitor, float const &a) {
 
 	rectData.round = m_iRounding != 0;
 	rectData.roundingPower = m_iRounding ;
-	g_pHyprRenderer->m_renderPass.add(makeShared<CRectPassElement>(rectData));
 
 
+	g_pHyprRenderer->m_renderPass.add(makeUnique<CRectPassElement>(rectData));
 	if (m_iBorderSize) {
 		CBox       borderBox = {DECOBOX.x, DECOBOX.y, static_cast<double>(layoutWidth), static_cast<double>(layoutHeight)};
 		borderBox.translate(pMonitor->m_position*-1).scale(pMonitor->m_scale).round();
@@ -180,16 +171,18 @@ void CHyprEasyLabel::draw(PHLMONITOR pMonitor, float const &a) {
 			borderData.roundingPower = m_iRounding;
 			borderData.borderSize = m_iBorderSize;
 			borderData.a = a;
-			g_pHyprRenderer->m_renderPass.add(makeShared<CBorderPassElement>(borderData));
+			g_pHyprRenderer->m_renderPass.add(makeUnique<CBorderPassElement>(borderData));
 			//g_pHyprOpenGL->renderBorder(borderBox, m_cBorderGradient, scaledRounding, m_iBorderSize * pMonitor->scale, a);
 		}
 	}
-
+	
 	CTexPassElement::SRenderData texData;
 	motionBox.round();
 	texData.tex = m_tTextTex;
 	texData.box = motionBox;
-	g_pHyprRenderer->m_renderPass.add(makeShared<CTexPassElement>(texData));
+
+
+	g_pHyprRenderer->m_renderPass.add(makeUnique<CTexPassElement>(texData));
 }
 
 eDecorationType CHyprEasyLabel::getDecorationType() {

--- a/easymotionDeco.cpp
+++ b/easymotionDeco.cpp
@@ -13,39 +13,39 @@
 #include "globals.hpp"
 
 CHyprEasyLabel::CHyprEasyLabel(PHLWINDOW pWindow, SMotionActionDesc *actionDesc) : IHyprWindowDecoration(pWindow) {
-    m_pWindow = pWindow;
+	m_pWindow = pWindow;
 
-    const auto PMONITOR       = pWindow->m_monitor.lock();
-    PMONITOR->m_scheduledRecalc = true;
-		m_szWindowAddress = std::format("0x{:x}", (uintptr_t)pWindow.get());
-		m_szActionCmd = std::vformat(actionDesc->commandString, std::make_format_args(m_szWindowAddress));
-		m_iTextSize = actionDesc->textSize;
-	  m_cTextColor = actionDesc->textColor;
-		m_cBackgroundColor = actionDesc->backgroundColor;
-		m_szTextFont = actionDesc->textFont;
-		m_iPaddingTop = actionDesc->boxPadding.m_top;
-		m_iPaddingBottom = actionDesc->boxPadding.m_bottom;
-		m_iPaddingRight = actionDesc->boxPadding.m_right;
-		m_iPaddingLeft = actionDesc->boxPadding.m_left;
-		m_iRounding = actionDesc->rounding;
-		m_iBorderSize = actionDesc->borderSize;
-		m_cBorderGradient = actionDesc->borderColor;
-    m_iBlur = actionDesc->blur;
-    m_iBlurA = actionDesc->blurA;
-    m_iXray = actionDesc->xray;
+	const auto PMONITOR       = pWindow->m_monitor.lock();
+	PMONITOR->m_scheduledRecalc = true;
+	m_szWindowAddress = std::format("0x{:x}", (uintptr_t)pWindow.get());
+	m_szActionCmd = std::vformat(actionDesc->commandString, std::make_format_args(m_szWindowAddress));
+	m_iTextSize = actionDesc->textSize;
+	m_cTextColor = actionDesc->textColor;
+	m_cBackgroundColor = actionDesc->backgroundColor;
+	m_szTextFont = actionDesc->textFont;
+	m_iPaddingTop = actionDesc->boxPadding.m_top;
+	m_iPaddingBottom = actionDesc->boxPadding.m_bottom;
+	m_iPaddingRight = actionDesc->boxPadding.m_right;
+	m_iPaddingLeft = actionDesc->boxPadding.m_left;
+	m_iRounding = actionDesc->rounding;
+	m_iBorderSize = actionDesc->borderSize;
+	m_cBorderGradient = actionDesc->borderColor;
+	m_iBlur = actionDesc->blur;
+	m_iBlurA = actionDesc->blurA;
+	m_iXray = actionDesc->xray;
 }
 
 CHyprEasyLabel::~CHyprEasyLabel() {
-    damageEntire();
-    std::erase(g_pGlobalState->motionLabels, m_self);
+	damageEntire();
+	std::erase(g_pGlobalState->motionLabels, m_self);
 }
 
 SDecorationPositioningInfo CHyprEasyLabel::getPositioningInfo() {
-    SDecorationPositioningInfo info;
-    info.policy         = DECORATION_POSITION_ABSOLUTE;
-    info.edges = DECORATION_EDGE_BOTTOM;
-    info.priority = 10000;
-    return info;
+	SDecorationPositioningInfo info;
+	info.policy         = DECORATION_POSITION_ABSOLUTE;
+	info.edges = DECORATION_EDGE_BOTTOM;
+	info.priority = 10000;
+	return info;
 }
 
 void CHyprEasyLabel::onPositioningReply(const SDecorationPositioningReply& reply) {
@@ -53,7 +53,7 @@ void CHyprEasyLabel::onPositioningReply(const SDecorationPositioningReply& reply
 }
 
 std::string CHyprEasyLabel::getDisplayName() {
-    return "EasyMotion";
+	return "EasyMotion";
 }
 
 void CHyprEasyLabel::renderMotionString(Vector2D& bufferSize, const float scale) {
@@ -99,141 +99,139 @@ void CHyprEasyLabel::renderMotionString(Vector2D& bufferSize, const float scale)
 	cairo_surface_flush(CAIROSURFACE);
 	const auto DATA = cairo_image_surface_get_data(CAIROSURFACE);
 	m_tTextTex->allocate();
-  m_tTextTex->m_size = {bufferSize.x, bufferSize.y};
-  glBindTexture(GL_TEXTURE_2D, m_tTextTex->m_texID);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
+	m_tTextTex->m_size = {bufferSize.x, bufferSize.y};
+	glBindTexture(GL_TEXTURE_2D, m_tTextTex->m_texID);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
 
 #ifndef GLES2
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_BLUE);
-  glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_RED);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_R, GL_BLUE);
+	glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_SWIZZLE_B, GL_RED);
 #endif
 
-  glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, bufferSize.x, bufferSize.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, DATA);
+	glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, bufferSize.x, bufferSize.y, 0, GL_RGBA, GL_UNSIGNED_BYTE, DATA);
 
-    // delete cairo
+	// delete cairo
 	cairo_destroy(LAYOUTCAIRO);
-  cairo_destroy(CAIRO);
-  cairo_surface_destroy(CAIROSURFACE);
+	cairo_destroy(CAIRO);
+	cairo_surface_destroy(CAIROSURFACE);
 
-  //renderText doesn't use ink_rect, but logical_rect. Makes the rectangle too tall
-  //m_tTextTex = g_pHyprOpenGL->renderText(m_szLabel, m_cTextColor, textSize, false, m_szTextFont, bufferSize.x-2);
+	//renderText doesn't use ink_rect, but logical_rect. Makes the rectangle too tall
+	//m_tTextTex = g_pHyprOpenGL->renderText(m_szLabel, m_cTextColor, textSize, false, m_szTextFont, bufferSize.x-2);
 }
 
 
 void CHyprEasyLabel::draw(PHLMONITOR pMonitor, float const &a) {
-    if (!validMapped(m_pWindow))
-        return;
- 
-    const auto PWINDOW = m_pWindow.lock();
+	if (!validMapped(m_pWindow))
+		return;
 
-    if (!PWINDOW->m_windowData.decorate.valueOrDefault())
-        return;
+	const auto PWINDOW = m_pWindow.lock();
 
-    const auto PWORKSPACE      = PWINDOW->m_workspace;
-    const auto WORKSPACEOFFSET = PWORKSPACE && !PWINDOW->m_pinned ? PWORKSPACE->m_renderOffset->value() : Vector2D();
+	if (!PWINDOW->m_windowData.decorate.valueOrDefault())
+		return;
 
-    const auto DECOBOX = assignedBoxGlobal();
+	const auto PWORKSPACE      = PWINDOW->m_workspace;
+	const auto WORKSPACEOFFSET = PWORKSPACE && !PWINDOW->m_pinned ? PWORKSPACE->m_renderOffset->value() : Vector2D();
 
-    const auto BARBUF = DECOBOX.size() * pMonitor->m_scale;
+	const auto DECOBOX = assignedBoxGlobal();
 
-    //CBox       motionBox = {DECOBOX.x - pMonitor->vecPosition.x, DECOBOX.y - pMonitor->vecPosition.y, DECOBOX.w,
+	const auto BARBUF = DECOBOX.size() * pMonitor->m_scale;
+
+	//CBox       motionBox = {DECOBOX.x - pMonitor->vecPosition.x, DECOBOX.y - pMonitor->vecPosition.y, DECOBOX.w,
 	
-		auto TEXTBUF = DECOBOX.size();
-	
+	auto TEXTBUF = DECOBOX.size();
 
-		if (!m_tTextTex.get()) {
-			renderMotionString(TEXTBUF, pMonitor->m_scale);
+
+	if (!m_tTextTex.get()) {
+		renderMotionString(TEXTBUF, pMonitor->m_scale);
+	}
+
+	CBox       motionBox = {DECOBOX.x, DECOBOX.y, m_tTextTex->m_size.x, m_tTextTex->m_size.y};
+	motionBox.translate(pMonitor->m_position*-1).scale(pMonitor->m_scale).round();
+
+	if (motionBox.w < 1 || motionBox.h < 1)
+	{
+		return;
+	}
+
+	CRectPassElement::SRectData rectData;
+	rectData.color = m_cBackgroundColor;
+	rectData.box = motionBox;
+	rectData.clipBox = motionBox;
+	rectData.blur = m_iBlur;
+	if (m_iBlur) {
+		rectData.blurA = m_iBlurA;
+		rectData.xray = m_iXray;
+	}
+
+	rectData.round = m_iRounding != 0;
+	rectData.roundingPower = m_iRounding ;
+	g_pHyprRenderer->m_renderPass.add(makeShared<CRectPassElement>(rectData));
+
+
+	if (m_iBorderSize) {
+		CBox       borderBox = {DECOBOX.x, DECOBOX.y, static_cast<double>(layoutWidth), static_cast<double>(layoutHeight)};
+		borderBox.translate(pMonitor->m_position*-1).scale(pMonitor->m_scale).round();
+		if (borderBox.w >= 1 && borderBox.h >= 1) {
+			CBorderPassElement::SBorderData borderData;
+			borderData.box = borderBox;
+			borderData.grad1 = m_cBorderGradient;
+			borderData.round = m_iRounding != 0;
+			borderData.roundingPower = m_iRounding;
+			borderData.borderSize = m_iBorderSize;
+			borderData.a = a;
+			g_pHyprRenderer->m_renderPass.add(makeShared<CBorderPassElement>(borderData));
+			//g_pHyprOpenGL->renderBorder(borderBox, m_cBorderGradient, scaledRounding, m_iBorderSize * pMonitor->scale, a);
 		}
+	}
 
-    CBox       motionBox = {DECOBOX.x, DECOBOX.y, m_tTextTex->m_size.x, m_tTextTex->m_size.y};
-    motionBox.translate(pMonitor->m_position*-1).scale(pMonitor->m_scale).round();
-
-    if (motionBox.w < 1 || motionBox.h < 1)
-    {
-        return;
-   }
-
-    CRectPassElement::SRectData rectData;
-    rectData.color = m_cBackgroundColor;
-    rectData.box = motionBox;
-    rectData.clipBox = motionBox;
-    rectData.blur = m_iBlur;
-    if (m_iBlur) {
-      rectData.blurA = m_iBlurA;
-      rectData.xray = m_iXray;
-    }
-
-    rectData.round = m_iRounding != 0;
-    rectData.roundingPower = m_iRounding ;
-    g_pHyprRenderer->m_renderPass.add(makeShared<CRectPassElement>(rectData));
-    
-		
-		if (m_iBorderSize) {
-    	CBox       borderBox = {DECOBOX.x, DECOBOX.y, static_cast<double>(layoutWidth), static_cast<double>(layoutHeight)};
-    	borderBox.translate(pMonitor->m_position*-1).scale(pMonitor->m_scale).round();
-			if (borderBox.w >= 1 && borderBox.h >= 1) {
-        CBorderPassElement::SBorderData borderData;
-        borderData.box = borderBox;
-        borderData.grad1 = m_cBorderGradient;
-        borderData.round = m_iRounding != 0;
-        borderData.roundingPower = m_iRounding;
-        borderData.borderSize = m_iBorderSize;
-        borderData.a = a;
-        g_pHyprRenderer->m_renderPass.add(makeShared<CBorderPassElement>(borderData));
-				//g_pHyprOpenGL->renderBorder(borderBox, m_cBorderGradient, scaledRounding, m_iBorderSize * pMonitor->scale, a);
-			}
-		}
-  
-    CTexPassElement::SRenderData texData;
-    motionBox.round();
-    texData.tex = m_tTextTex;
-    texData.box = motionBox;
-    g_pHyprRenderer->m_renderPass.add(makeShared<CTexPassElement>(texData));
-  
-  
+	CTexPassElement::SRenderData texData;
+	motionBox.round();
+	texData.tex = m_tTextTex;
+	texData.box = motionBox;
+	g_pHyprRenderer->m_renderPass.add(makeShared<CTexPassElement>(texData));
 }
 
 eDecorationType CHyprEasyLabel::getDecorationType() {
-    return DECORATION_CUSTOM;
+	return DECORATION_CUSTOM;
 }
 
 void CHyprEasyLabel::updateWindow(PHLWINDOW pWindow) {
-    damageEntire();
+	damageEntire();
 }
 
 void CHyprEasyLabel::damageEntire() {
-  auto box = assignedBoxGlobal();
-  box.translate(m_pWindow->m_floatingOffset);
-  g_pHyprRenderer->damageBox(box);
+	auto box = assignedBoxGlobal();
+	box.translate(m_pWindow->m_floatingOffset);
+	g_pHyprRenderer->damageBox(box);
 }
 
 eDecorationLayer CHyprEasyLabel::getDecorationLayer() {
-    return DECORATION_LAYER_OVER;
+	return DECORATION_LAYER_OVER;
 }
 
 uint64_t CHyprEasyLabel::getDecorationFlags() {
-    return DECORATION_PART_OF_MAIN_WINDOW;
+	return DECORATION_PART_OF_MAIN_WINDOW;
 }
 
 CBox CHyprEasyLabel::assignedBoxGlobal() {
 
-    const auto PWINDOW = m_pWindow.lock();
-		double boxHeight, boxWidth;
-		double boxSize;
-		boxHeight = PWINDOW->m_realSize->value().y * 0.10;
-		boxWidth = PWINDOW->m_realSize->value().x * 0.10;
-		boxSize = std::min(boxHeight, boxWidth);
-	  double boxX = PWINDOW->m_realPosition->value().x + (PWINDOW->m_realSize->value().x-boxSize)/2;
-	  double boxY = PWINDOW->m_realPosition->value().y + (PWINDOW->m_realSize->value().y-boxSize)/2;
-    CBox box = {boxX, boxY, boxSize, boxSize};
+	const auto PWINDOW = m_pWindow.lock();
+	double boxHeight, boxWidth;
+	double boxSize;
+	boxHeight = PWINDOW->m_realSize->value().y * 0.10;
+	boxWidth = PWINDOW->m_realSize->value().x * 0.10;
+	boxSize = std::min(boxHeight, boxWidth);
+	double boxX = PWINDOW->m_realPosition->value().x + (PWINDOW->m_realSize->value().x-boxSize)/2;
+	double boxY = PWINDOW->m_realPosition->value().y + (PWINDOW->m_realSize->value().y-boxSize)/2;
+	CBox box = {boxX, boxY, boxSize, boxSize};
 
-    const auto PWORKSPACE      = PWINDOW->m_workspace;
-    const auto WORKSPACEOFFSET = PWORKSPACE && !PWINDOW->m_pinned ? PWORKSPACE->m_renderOffset->value() : Vector2D();
+	const auto PWORKSPACE      = PWINDOW->m_workspace;
+	const auto WORKSPACEOFFSET = PWORKSPACE && !PWINDOW->m_pinned ? PWORKSPACE->m_renderOffset->value() : Vector2D();
 
-    return box.translate(WORKSPACEOFFSET);
+	return box.translate(WORKSPACEOFFSET);
 }
 
 PHLWINDOW CHyprEasyLabel::getOwner() {
-    return m_pWindow.lock();
+	return m_pWindow.lock();
 }

--- a/easymotionDeco.hpp
+++ b/easymotionDeco.hpp
@@ -36,7 +36,8 @@ class CHyprEasyLabel : public IHyprWindowDecoration {
 
 		PHLWINDOW                          getOwner();
 
-		std::string	                       m_szLabel;
+		std::string                        m_szKey;
+		std::string                        m_szLabel;
 		std::string                        m_szActionCmd;
 		std::string                        m_szTextFont;
 		std::string                        m_szWindowAddress;
@@ -62,7 +63,7 @@ class CHyprEasyLabel : public IHyprWindowDecoration {
 
 
 	private:
-		int	        layoutWidth;
+		int         layoutWidth;
 		int         layoutHeight;
 		SBoxExtents m_seExtents;
 

--- a/easymotionDeco.hpp
+++ b/easymotionDeco.hpp
@@ -10,72 +10,72 @@
 #include "globals.hpp"
 
 class CHyprEasyLabel : public IHyprWindowDecoration {
-  public:
-    CHyprEasyLabel(PHLWINDOW, SMotionActionDesc *actionDesc);
-    virtual ~CHyprEasyLabel();
+	public:
+		CHyprEasyLabel(PHLWINDOW, SMotionActionDesc *actionDesc);
+		virtual ~CHyprEasyLabel();
 
-    virtual SDecorationPositioningInfo getPositioningInfo();
+		virtual SDecorationPositioningInfo getPositioningInfo();
 
-    virtual void                       onPositioningReply(const SDecorationPositioningReply& reply);
+		virtual void                       onPositioningReply(const SDecorationPositioningReply& reply);
 
-    virtual void                       draw(PHLMONITOR, float const &a);
+		virtual void                       draw(PHLMONITOR, float const &a);
 
-    virtual eDecorationType            getDecorationType();
+		virtual eDecorationType            getDecorationType();
 
-    virtual void                       updateWindow(PHLWINDOW);
+		virtual void                       updateWindow(PHLWINDOW);
 
-    virtual void                       damageEntire();
+		virtual void                       damageEntire();
 
-    virtual eDecorationLayer           getDecorationLayer();
+		virtual eDecorationLayer           getDecorationLayer();
 
-    virtual uint64_t                   getDecorationFlags();
+		virtual uint64_t                   getDecorationFlags();
 
-    bool                               m_bButtonsDirty = true;
+		bool                               m_bButtonsDirty = true;
 
-    virtual std::string                getDisplayName();
+		virtual std::string                getDisplayName();
 
-    PHLWINDOW                           getOwner();
+		PHLWINDOW                          getOwner();
 
-		std::string												 m_szLabel;
-		std::string  											 m_szActionCmd;
-		std::string												 m_szTextFont;
-	  std::string                        m_szWindowAddress;
-		int																 m_iTextSize;
-		int																 m_iPaddingTop;
-		int																 m_iPaddingBottom;
-		int																 m_iPaddingLeft;
-		int																 m_iPaddingRight;
-		int 															 m_iRounding;
-    int                                m_iBlur;
-    int                                m_iXray;
-    float                              m_iBlurA;
+		std::string	                       m_szLabel;
+		std::string                        m_szActionCmd;
+		std::string                        m_szTextFont;
+		std::string                        m_szWindowAddress;
+		int                                m_iTextSize;
+		int                                m_iPaddingTop;
+		int                                m_iPaddingBottom;
+		int                                m_iPaddingLeft;
+		int                                m_iPaddingRight;
+		int                                m_iRounding;
+		int                                m_iBlur;
+		int                                m_iXray;
+		float                              m_iBlurA;
 
-		CHyprColor		  											 m_cTextColor;
-		CHyprColor														 m_cBackgroundColor;
-		int																 m_iBorderSize;
-		CGradientValueData								 m_cBorderGradient;
-    WP<CHyprEasyLabel>                 m_self;
-    eFullscreenMode                    m_origFSMode;
-
-
-	
+		CHyprColor                         m_cTextColor;
+		CHyprColor                         m_cBackgroundColor;
+		int                                m_iBorderSize;
+		CGradientValueData                 m_cBorderGradient;
+		WP<CHyprEasyLabel>                 m_self;
+		eFullscreenMode                    m_origFSMode;
 
 
-  private:
-		int			layoutWidth;
-		int     layoutHeight;
-    SBoxExtents m_seExtents;
 
-    PHLWINDOWREF                 m_pWindow;
 
-    SP<CTexture>                 m_tTextTex;
 
-    bool                     m_bWindowSizeChanged = false;
+	private:
+		int	        layoutWidth;
+		int         layoutHeight;
+		SBoxExtents m_seExtents;
 
-    void                     renderText(CTexture& out, const std::string& text, const CHyprColor& color, const Vector2D& bufferSize, const float scale, const int fontSize);
-    CBox                     assignedBoxGlobal();
-		void 										 renderMotionString(Vector2D& bufferSize, const float scale);
+		PHLWINDOWREF             m_pWindow;
 
-    // for dynamic updates
-    int m_iLastHeight = 0;
+		SP<CTexture>             m_tTextTex;
+
+		bool                     m_bWindowSizeChanged = false;
+
+		void                     renderText(CTexture& out, const std::string& text, const CHyprColor& color, const Vector2D& bufferSize, const float scale, const int fontSize);
+		CBox                     assignedBoxGlobal();
+		void                     renderMotionString(Vector2D& bufferSize, const float scale);
+
+		// for dynamic updates
+		int m_iLastHeight = 0;
 };

--- a/flake.lock
+++ b/flake.lock
@@ -20,16 +20,54 @@
         ]
       },
       "locked": {
-        "lastModified": 1726665257,
-        "narHash": "sha256-rEzEZtd3iyVo5RJ1OGujOlnywNf3gsrOnjAn1NLciD4=",
+        "lastModified": 1751740947,
+        "narHash": "sha256-35040CHH7P3JGmhGVfEb2oJHL/A5mI2IXumhkxrBnao=",
         "owner": "hyprwm",
         "repo": "aquamarine",
-        "rev": "752d0fbd141fabb5a1e7f865199b80e6e76f8d8e",
+        "rev": "dfc1db15a08c4cd234288f66e1199c653495301f",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
         "repo": "aquamarine",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "hyprland",
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1709087332,
+        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
         "type": "github"
       }
     },
@@ -49,16 +87,45 @@
         ]
       },
       "locked": {
-        "lastModified": 1722623071,
-        "narHash": "sha256-sLADpVgebpCBFXkA1FlCXtvEPu1tdEsTfqK1hfeHySE=",
+        "lastModified": 1749155331,
+        "narHash": "sha256-XR9fsI0zwLiFWfqi/pdS/VD+YNorKb3XIykgTg4l1nA=",
         "owner": "hyprwm",
         "repo": "hyprcursor",
-        "rev": "912d56025f03d41b1ad29510c423757b4379eb1c",
+        "rev": "45fcc10b4c282746d93ec406a740c43b48b4ef80",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
         "repo": "hyprcursor",
+        "type": "github"
+      }
+    },
+    "hyprgraphics": {
+      "inputs": {
+        "hyprutils": [
+          "hyprland",
+          "hyprutils"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1751808145,
+        "narHash": "sha256-OXgL0XaKMmfX2rRQkt9SkJw+QNfv0jExlySt1D6O72g=",
+        "owner": "hyprwm",
+        "repo": "hyprgraphics",
+        "rev": "b841473a0bd4a1a74a0b64f1ec2ab199035c349f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprgraphics",
         "type": "github"
       }
     },
@@ -66,53 +133,121 @@
       "inputs": {
         "aquamarine": "aquamarine",
         "hyprcursor": "hyprcursor",
+        "hyprgraphics": "hyprgraphics",
+        "hyprland-protocols": "hyprland-protocols",
+        "hyprland-qtutils": "hyprland-qtutils",
         "hyprlang": "hyprlang",
         "hyprutils": "hyprutils",
         "hyprwayland-scanner": "hyprwayland-scanner",
         "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks",
         "systems": "systems",
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1726995313,
-        "narHash": "sha256-HTbsXJDFugdQ794d1Bnh8eRSY7AlunIxd7jFW9kkKNM=",
-        "ref": "refs/heads/main",
-        "rev": "e5ff19ac0f2c8d53a0c847d06a17676e636d6447",
-        "revCount": 5247,
-        "submodules": true,
-        "type": "git",
-        "url": "https://github.com/hyprwm/Hyprland"
+        "lastModified": 1752682974,
+        "narHash": "sha256-qjfHaJGfTfBHUTwibfYyeSthiSn246fZvNGiJ9stEAc=",
+        "owner": "hyprwm",
+        "repo": "Hyprland",
+        "rev": "148718b3bcffaa90cd684df90860fd5bda37907f",
+        "type": "github"
       },
       "original": {
-        "submodules": true,
-        "type": "git",
-        "url": "https://github.com/hyprwm/Hyprland"
+        "owner": "hyprwm",
+        "repo": "Hyprland",
+        "type": "github"
       }
     },
     "hyprland-protocols": {
       "inputs": {
         "nixpkgs": [
           "hyprland",
-          "xdph",
           "nixpkgs"
         ],
         "systems": [
           "hyprland",
-          "xdph",
           "systems"
         ]
       },
       "locked": {
-        "lastModified": 1721326555,
-        "narHash": "sha256-zCu4R0CSHEactW9JqYki26gy8h9f6rHmSwj4XJmlHgg=",
+        "lastModified": 1749046714,
+        "narHash": "sha256-kymV5FMnddYGI+UjwIw8ceDjdeg7ToDVjbHCvUlhn14=",
         "owner": "hyprwm",
         "repo": "hyprland-protocols",
-        "rev": "5a11232266bf1a1f5952d5b179c3f4b2facaaa84",
+        "rev": "613878cb6f459c5e323aaafe1e6f388ac8a36330",
         "type": "github"
       },
       "original": {
         "owner": "hyprwm",
         "repo": "hyprland-protocols",
+        "type": "github"
+      }
+    },
+    "hyprland-qt-support": {
+      "inputs": {
+        "hyprlang": [
+          "hyprland",
+          "hyprland-qtutils",
+          "hyprlang"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "hyprland-qtutils",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "hyprland-qtutils",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1749154592,
+        "narHash": "sha256-DO7z5CeT/ddSGDEnK9mAXm1qlGL47L3VAHLlLXoCjhE=",
+        "owner": "hyprwm",
+        "repo": "hyprland-qt-support",
+        "rev": "4c8053c3c888138a30c3a6c45c2e45f5484f2074",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprland-qt-support",
+        "type": "github"
+      }
+    },
+    "hyprland-qtutils": {
+      "inputs": {
+        "hyprland-qt-support": "hyprland-qt-support",
+        "hyprlang": [
+          "hyprland",
+          "hyprlang"
+        ],
+        "hyprutils": [
+          "hyprland",
+          "hyprland-qtutils",
+          "hyprlang",
+          "hyprutils"
+        ],
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ],
+        "systems": [
+          "hyprland",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1750371812,
+        "narHash": "sha256-D868K1dVEACw17elVxRgXC6hOxY+54wIEjURztDWLk8=",
+        "owner": "hyprwm",
+        "repo": "hyprland-qtutils",
+        "rev": "b13c7481e37856f322177010bdf75fccacd1adc8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hyprwm",
+        "repo": "hyprland-qtutils",
         "type": "github"
       }
     },
@@ -132,11 +267,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1725997860,
-        "narHash": "sha256-d/rZ/fHR5l1n7PeyLw0StWMNLXVU9c4HFyfskw568so=",
+        "lastModified": 1750371198,
+        "narHash": "sha256-/iuJ1paQOBoSLqHflRNNGyroqfF/yvPNurxzcCT0cAE=",
         "owner": "hyprwm",
         "repo": "hyprlang",
-        "rev": "dfeb5811dd6485490cce18d6cc1e38a055eea876",
+        "rev": "cee01452bca58d6cadb3224e21e370de8bc20f0b",
         "type": "github"
       },
       "original": {
@@ -157,11 +292,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724966483,
-        "narHash": "sha256-WXDgKIbzjYKczxSZOsJplCS1i1yrTUpsDPuJV/xpYLo=",
+        "lastModified": 1751888065,
+        "narHash": "sha256-F2SV9WGqgtRsXIdUrl3sRe0wXlQD+kRRZcSfbepjPJY=",
         "owner": "hyprwm",
         "repo": "hyprutils",
-        "rev": "8976e3f6a5357da953a09511d0c7f6a890fb6ec2",
+        "rev": "a8229739cf36d159001cfc203871917b83fdf917",
         "type": "github"
       },
       "original": {
@@ -182,11 +317,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1721324119,
-        "narHash": "sha256-SOOqIT27/X792+vsLSeFdrNTF+OSRp5qXv6Te+fb2Qg=",
+        "lastModified": 1751881472,
+        "narHash": "sha256-meB0SnXbwIe2trD041MLKEv6R7NZ759QwBcVIhlSBfE=",
         "owner": "hyprwm",
         "repo": "hyprwayland-scanner",
-        "rev": "a048a6cb015340bd82f97c1f40a4b595ca85cc30",
+        "rev": "8fb426b3e5452fd9169453fd6c10f8c14ca37120",
         "type": "github"
       },
       "original": {
@@ -197,11 +332,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1725983898,
-        "narHash": "sha256-4b3A9zPpxAxLnkF9MawJNHDtOOl6ruL0r6Og1TEDGCE=",
+        "lastModified": 1751792365,
+        "narHash": "sha256-J1kI6oAj25IG4EdVlg2hQz8NZTBNYvIS0l4wpr9KcUo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1355a0cbfeac61d785b7183c0caaec1f97361b43",
+        "rev": "1fd8bada0b6117e6c7eb54aad5813023eed37ccb",
         "type": "github"
       },
       "original": {
@@ -213,17 +348,40 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1726755586,
-        "narHash": "sha256-PmUr/2GQGvFTIJ6/Tvsins7Q43KTMvMFhvG6oaYK+Wk=",
+        "lastModified": 1752480373,
+        "narHash": "sha256-JHQbm+OcGp32wAsXTE/FLYGNpb+4GLi5oTvCxwSoBOA=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "c04d5652cfa9742b1d519688f65d1bbccea9eb7e",
+        "rev": "62e0f05ede1da0d54515d4ea8ce9c733f12d9f08",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "gitignore": "gitignore",
+        "nixpkgs": [
+          "hyprland",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1750779888,
+        "narHash": "sha256-wibppH3g/E2lxU43ZQHC5yA/7kIKLGxVEnsnVK1BtRg=",
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
+        "rev": "16ec914f6fb6f599ce988427d9d94efddf25fe6d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "git-hooks.nix",
         "type": "github"
       }
     },
@@ -250,10 +408,21 @@
     },
     "xdph": {
       "inputs": {
-        "hyprland-protocols": "hyprland-protocols",
+        "hyprland-protocols": [
+          "hyprland",
+          "hyprland-protocols"
+        ],
         "hyprlang": [
           "hyprland",
           "hyprlang"
+        ],
+        "hyprutils": [
+          "hyprland",
+          "hyprutils"
+        ],
+        "hyprwayland-scanner": [
+          "hyprland",
+          "hyprwayland-scanner"
         ],
         "nixpkgs": [
           "hyprland",
@@ -265,11 +434,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1726046979,
-        "narHash": "sha256-6SEsjurq9cdTkITA6d49ncAJe4O/8CgRG5/F//s6Xh8=",
+        "lastModified": 1751300244,
+        "narHash": "sha256-PFuv1TZVYvQhha0ac53E3YgdtmLShrN0t4T6xqHl0jE=",
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
-        "rev": "e695669fd8e1d1be9eaae40f35e00f8bd8b64c18",
+        "rev": "6115f3fdcb2c1a57b4a80a69f3c797e47607b90a",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,45 +1,45 @@
 # Nix config informed by VirtCode's 'Dynamic Cursor'
 # https://github.com/VirtCode/hypr-dynamic-cursors
 {
-  description = "Easymotion, for hyprland";
+	description = "Easymotion, for hyprland";
 
-  inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
-    hyprland.url = "git+https://github.com/hyprwm/Hyprland?submodules=1";
-  };
+	inputs = {
+		nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
+		hyprland.url = "git+https://github.com/hyprwm/Hyprland?submodules=1";
+	};
 
-  outputs = {
-    self,
-    nixpkgs,
-    ...
-  } @ inputs: let
-    forAllSystems = function:
-      nixpkgs.lib.genAttrs [
-        "x86_64-linux"
-      ] (system: function nixpkgs.legacyPackages.${system});
-  in {
-    packages = forAllSystems (pkgs: {
-      default = self.packages.${pkgs.system}.hyprland-easymotion;
-      hyprland-easymotion = pkgs.stdenvNoCC.mkDerivation rec {
-        name = "hyprland-easymotion";
-        pname = name;
-        src = ./.;
-        nativeBuildInputs = inputs.hyprland.packages.${pkgs.system}.hyprland.nativeBuildInputs ++ [inputs.hyprland.packages.${pkgs.system}.hyprland pkgs.gcc13];
-        buildInputs = inputs.hyprland.packages.${pkgs.system}.hyprland.buildInputs;
+	outputs = {
+		self,
+		nixpkgs,
+		...
+	} @ inputs: let
+		forAllSystems = function:
+			nixpkgs.lib.genAttrs [
+				"x86_64-linux"
+			] (system: function nixpkgs.legacyPackages.${system});
+	in {
+		packages = forAllSystems (pkgs: {
+			default = self.packages.${pkgs.system}.hyprland-easymotion;
+			hyprland-easymotion = pkgs.stdenvNoCC.mkDerivation rec {
+				name = "hyprland-easymotion";
+				pname = name;
+				src = ./.;
+				nativeBuildInputs = inputs.hyprland.packages.${pkgs.system}.hyprland.nativeBuildInputs ++ [inputs.hyprland.packages.${pkgs.system}.hyprland pkgs.gcc13];
+				buildInputs = inputs.hyprland.packages.${pkgs.system}.hyprland.buildInputs;
 
-        dontUseCmakeConfigure = true;
-        dontUseMesonConfigure = true;
-        dontUseNinjaBuild = true;
-        dontUseNinjaInstall = true;
+				dontUseCmakeConfigure = true;
+				dontUseMesonConfigure = true;
+				dontUseNinjaBuild = true;
+				dontUseNinjaInstall = true;
 
-        installPhase = ''
-        runHook preInstall
+				installPhase = ''
+				runHook preInstall
 
-        mkdir -p "$out/lib"
-        cp -r ./hypreasymotion.so "$out/lib/libhyprland-easymotion.so"
-        runHook postInstall
-        '';
-      };
-    });
-  };
+				mkdir -p "$out/lib"
+				cp -r ./hypreasymotion.so "$out/lib/libhyprland-easymotion.so"
+				runHook postInstall
+				'';
+			};
+		});
+	};
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,16 +1,15 @@
-# Nix config informed by VirtCode's 'Dynamic Cursor'
-# https://github.com/VirtCode/hypr-dynamic-cursors
 {
 	description = "Easymotion, for hyprland";
 
 	inputs = {
+		hyprland.url = "github:hyprwm/Hyprland";
 		nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
-		hyprland.url = "git+https://github.com/hyprwm/Hyprland?submodules=1";
 	};
 
 	outputs = {
 		self,
 		nixpkgs,
+		hyprland,
 		...
 	} @ inputs: let
 		forAllSystems = function:
@@ -20,24 +19,27 @@
 	in {
 		packages = forAllSystems (pkgs: {
 			default = self.packages.${pkgs.system}.hyprland-easymotion;
-			hyprland-easymotion = pkgs.stdenvNoCC.mkDerivation rec {
+			hyprland-easymotion = hyprland.packages.${pkgs.system}.hyprland.stdenv.mkDerivation rec {
 				name = "hyprland-easymotion";
 				pname = name;
 				src = ./.;
-				nativeBuildInputs = inputs.hyprland.packages.${pkgs.system}.hyprland.nativeBuildInputs ++ [inputs.hyprland.packages.${pkgs.system}.hyprland pkgs.gcc13];
-				buildInputs = inputs.hyprland.packages.${pkgs.system}.hyprland.buildInputs;
 
-				dontUseCmakeConfigure = true;
-				dontUseMesonConfigure = true;
 				dontUseNinjaBuild = true;
 				dontUseNinjaInstall = true;
+				dontUseCmakeConfigure = true;
+				dontUseMesonConfigure = true;
+
+				nativeBuildInputs = [
+					hyprland.packages.${pkgs.system}.hyprland.dev
+				] ++ inputs.hyprland.packages.${pkgs.system}.hyprland.nativeBuildInputs;
+				buildInputs = inputs.hyprland.packages.${pkgs.system}.hyprland.buildInputs;
 
 				installPhase = ''
-				runHook preInstall
+					runHook preInstall
 
-				mkdir -p "$out/lib"
-				cp -r ./hypreasymotion.so "$out/lib/libhyprland-easymotion.so"
-				runHook postInstall
+					mkdir -p "$out/lib"
+					cp -r ./hypreasymotion.so "$out/lib/libhyprland-easymotion.so"
+					runHook postInstall
 				'';
 			};
 		});

--- a/globals.hpp
+++ b/globals.hpp
@@ -8,11 +8,11 @@ inline HANDLE PHANDLE = nullptr;
 class CHyprEasyLabel;
 
 struct SGlobalState {
-    std::vector<WP<CHyprEasyLabel>>   motionLabels;
+	std::vector<WP<CHyprEasyLabel>>   motionLabels;
 };
 
 struct SMotionActionDesc {
-  int textSize = 15;
+	int textSize = 15;
 	CHyprColor textColor = CHyprColor(0,0,0,1);
 	CHyprColor backgroundColor = CHyprColor(1,1,1,1);
 	std::string textFont = "Sans";
@@ -21,12 +21,12 @@ struct SMotionActionDesc {
 	int borderSize = 0;
 	CGradientValueData borderColor = CGradientValueData();
 	int rounding = 0;
-  int blur = 0;
-  int xray = 0;
-  float blurA = 1.0f;
+	int blur = 0;
+	int xray = 0;
+	float blurA = 1.0f;
 	std::string motionKeys = "abcdefghijklmnopqrstuvwxyz1234567890";
-  std::string fullscreen_action = "none";
-  int only_special = 1;
+	std::string fullscreen_action = "none";
+	int only_special = 1;
 };
 
 inline UP<SGlobalState> g_pGlobalState;

--- a/globals.hpp
+++ b/globals.hpp
@@ -25,6 +25,7 @@ struct SMotionActionDesc {
 	int xray = 0;
 	float blurA = 1.0f;
 	std::string motionKeys = "abcdefghijklmnopqrstuvwxyz1234567890";
+	std::string motionLabels = "";
 	std::string fullscreen_action = "none";
 	int only_special = 1;
 };

--- a/main.cpp
+++ b/main.cpp
@@ -23,7 +23,7 @@ APICALL EXPORT std::string PLUGIN_API_VERSION() {
 SDispatchResult easymotionExitDispatch(std::string args)
 {
 	for (auto &ml : g_pGlobalState->motionLabels | std::ranges::views::reverse) {
-		if (ml->m_origFSMode != ml->getOwner()->m_sFullscreenState.internal)
+		if (ml->m_origFSMode != ml->getOwner()->m_fullscreenState.internal)
 			g_pCompositor->setWindowFullscreenInternal(ml->getOwner(), ml->m_origFSMode);
 		ml->getOwner()->removeWindowDeco(ml.get());
 	}
@@ -38,7 +38,7 @@ SDispatchResult easymotionActionDispatch(std::string args)
 	for (auto &ml : g_pGlobalState->motionLabels) {
 		if (ml->m_szKey == args) {
 			g_pEventManager->postEvent(SHyprIPCEvent{"easymotionselect", std::format("{},{}", ml->m_szWindowAddress, ml->m_szKey)});
-			g_pKeybindManager->m_mDispatchers["exec"](ml->m_szActionCmd);
+			g_pKeybindManager->m_dispatchers["exec"](ml->m_szActionCmd);
 			easymotionExitDispatch("");
 			break;
 		}

--- a/main.cpp
+++ b/main.cpp
@@ -16,20 +16,20 @@
 
 // Do NOT change this function.
 APICALL EXPORT std::string PLUGIN_API_VERSION() {
-    return HYPRLAND_API_VERSION;
+	return HYPRLAND_API_VERSION;
 }
 
 
 SDispatchResult easymotionExitDispatch(std::string args)
 {
-		for (auto &ml : g_pGlobalState->motionLabels | std::ranges::views::reverse) {
-        if (ml->m_origFSMode != ml->getOwner()->m_fullscreenState.internal)
-          g_pCompositor->setWindowFullscreenInternal(ml->getOwner(), ml->m_origFSMode);
-			  ml->getOwner()->removeWindowDeco(ml.get());
-		}
-		HyprlandAPI::invokeHyprctlCommand("dispatch", "submap reset");
-		g_pEventManager->postEvent(SHyprIPCEvent{"easymotionexit", ""});
-    return {};
+	for (auto &ml : g_pGlobalState->motionLabels | std::ranges::views::reverse) {
+		if (ml->m_origFSMode != ml->getOwner()->m_fullscreenState.internal)
+			g_pCompositor->setWindowFullscreenInternal(ml->getOwner(), ml->m_origFSMode);
+		ml->getOwner()->removeWindowDeco(ml.get());
+	}
+	HyprlandAPI::invokeHyprctlCommand("dispatch", "submap reset");
+	g_pEventManager->postEvent(SHyprIPCEvent{"easymotionexit", ""});
+	return {};
 
 }
 
@@ -44,16 +44,14 @@ SDispatchResult easymotionActionDispatch(std::string args)
 		}
 	}
 
-  return {};
+	return {};
 }
 
 void addEasyMotionKeybinds()
 {
-
-		g_pKeybindManager->addKeybind(SKeybind{"escape", {}, 0, 0, 0, {}, "easymotionexit", "", 0, "__easymotionsubmap__", "", 0, 0, 0, 0, 0, 0, 0, 0});
-	  //catchall
-		g_pKeybindManager->addKeybind(SKeybind{"", {}, 0, 1, 0, {}, "", "", 0, "__easymotionsubmap__", "", 0, 0, 0, 0, 0, 0, 0, 0});
-
+	g_pKeybindManager->addKeybind(SKeybind{"escape", {}, 0, 0, 0, {}, "easymotionexit", "", 0, "__easymotionsubmap__", "", 0, 0, 0, 0, 0, 0, 0, 0});
+	//catchall
+	g_pKeybindManager->addKeybind(SKeybind{"", {}, 0, 1, 0, {}, "", "", 0, "__easymotionsubmap__", "", 0, 0, 0, 0, 0, 0, 0, 0});
 }
 
 
@@ -62,81 +60,80 @@ void addLabelToWindow(PHLWINDOW window, SMotionActionDesc *actionDesc, std::stri
 	UP<CHyprEasyLabel> motionlabel = makeUnique<CHyprEasyLabel>(window, actionDesc);
 	motionlabel->m_szLabel = label;
 	g_pGlobalState->motionLabels.emplace_back(motionlabel);
-  motionlabel->m_self = motionlabel;
-  motionlabel->draw(window->m_monitor.lock(), 1.0);
-  motionlabel->m_origFSMode = window->m_fullscreenState.internal;
-  if ((motionlabel->m_origFSMode != eFullscreenMode::FSMODE_NONE) && (actionDesc->fullscreen_action != "none"))
-  {
-    if (actionDesc->fullscreen_action == "maximize")
-    {
-      g_pCompositor->setWindowFullscreenInternal(window, FSMODE_MAXIMIZED);
-    } else if (actionDesc->fullscreen_action == "toggle") {
-      g_pCompositor->setWindowFullscreenInternal(window, FSMODE_NONE);
-    }
-  }
+	motionlabel->m_self = motionlabel;
+	motionlabel->draw(window->m_monitor.lock(), 1.0);
+	motionlabel->m_origFSMode = window->m_fullscreenState.internal;
+	if ((motionlabel->m_origFSMode != eFullscreenMode::FSMODE_NONE) && (actionDesc->fullscreen_action != "none"))
+	{
+		if (actionDesc->fullscreen_action == "maximize")
+		{
+			g_pCompositor->setWindowFullscreenInternal(window, FSMODE_MAXIMIZED);
+		} else if (actionDesc->fullscreen_action == "toggle") {
+			g_pCompositor->setWindowFullscreenInternal(window, FSMODE_NONE);
+		}
+	}
 	HyprlandAPI::addWindowDecoration(PHANDLE, window, std::move(motionlabel));
 }
 
 static bool parseBorderGradient(std::string VALUE, CGradientValueData *DATA) {
-    std::string V = VALUE;
+	std::string V = VALUE;
 
-    CVarList   varlist(V, 0, ' ');
-    DATA->m_colors.clear();
+	CVarList   varlist(V, 0, ' ');
+	DATA->m_colors.clear();
 
-    std::string parseError = "";
+	std::string parseError = "";
 
-    for (auto& var : varlist) {
-        if (var.find("deg") != std::string::npos) {
-            // last arg
-            try {
-                DATA->m_angle = std::stoi(var.substr(0, var.find("deg"))) * (PI / 180.0); // radians
-            } catch (...) {
-                Debug::log(WARN, "Error parsing gradient {}", V);
-								return false;
-            }
+	for (auto& var : varlist) {
+		if (var.find("deg") != std::string::npos) {
+			// last arg
+			try {
+				DATA->m_angle = std::stoi(var.substr(0, var.find("deg"))) * (PI / 180.0); // radians
+			} catch (...) {
+				Debug::log(WARN, "Error parsing gradient {}", V);
+				return false;
+			}
 
-            break;
-        }
+			break;
+		}
 
-        if (DATA->m_colors.size() >= 10) {
-            Debug::log(WARN, "Error parsing gradient {}: max colors is 10.", V);
-						return false;
-            break;
-        }
+		if (DATA->m_colors.size() >= 10) {
+			Debug::log(WARN, "Error parsing gradient {}: max colors is 10.", V);
+			return false;
+		}
 
-        try {
-            DATA->m_colors.push_back(CHyprColor(configStringToInt(var).value_or(0)));
-        } catch (std::exception& e) {
-            Debug::log(WARN, "Error parsing gradient {}", V);
-        }
-    }
+		try {
+			DATA->m_colors.push_back(CHyprColor(configStringToInt(var).value_or(0)));
+		} catch (std::exception& e) {
+			Debug::log(WARN, "Error parsing gradient {}", V);
+		}
+	}
 
-    if (DATA->m_colors.size() == 0) {
-        Debug::log(WARN, "Error parsing gradient {}", V);
-        DATA->m_colors.push_back(0); // transparent
-    }
+	if (DATA->m_colors.size() == 0) {
+		Debug::log(WARN, "Error parsing gradient {}", V);
+		DATA->m_colors.push_back(0); // transparent
+	}
 
-    DATA->updateColorsOk();
-    return true;
+	DATA->updateColorsOk();
+	return true;
 }
 
 SDispatchResult easymotionDispatch(std::string args)
 {
-		static auto *const TEXTSIZE = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:textsize")->getDataStaticPtr();
+	static auto *const TEXTSIZE = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:textsize")->getDataStaticPtr();
 
-	  static auto *const TEXTCOLOR = (Hyprlang::INT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:textcolor")->getDataStaticPtr();
-		static auto *const BGCOLOR = (Hyprlang::INT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:bgcolor")->getDataStaticPtr();
-		static auto *const TEXTFONT = (Hyprlang::STRING const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:textfont")->getDataStaticPtr();
-		static auto *const TEXTPADDING = (Hyprlang::STRING const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:textpadding")->getDataStaticPtr();
-		static auto *const BORDERSIZE = (Hyprlang::INT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:bordersize")->getDataStaticPtr();
-		static auto *const BORDERCOLOR = (Hyprlang::STRING const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:bordercolor")->getDataStaticPtr();
-		static auto *const ROUNDING = (Hyprlang::INT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:rounding")->getDataStaticPtr();
-		static auto *const BLUR = (Hyprlang::INT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:blur")->getDataStaticPtr();
-		static auto *const XRAY = (Hyprlang::INT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:xray")->getDataStaticPtr();
-		static auto *const BLURA = (Hyprlang::FLOAT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:blurA")->getDataStaticPtr();
-		static auto *const MOTIONKEYS = (Hyprlang::STRING const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:motionkeys")->getDataStaticPtr();
-		static auto *const FSACTION = (Hyprlang::STRING const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:fullscreen_action")->getDataStaticPtr();
-		static auto *const ONLYSPECIAL = (Hyprlang::INT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:only_special")->getDataStaticPtr();
+	static auto *const TEXTCOLOR = (Hyprlang::INT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:textcolor")->getDataStaticPtr();
+	static auto *const BGCOLOR = (Hyprlang::INT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:bgcolor")->getDataStaticPtr();
+	static auto *const TEXTFONT = (Hyprlang::STRING const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:textfont")->getDataStaticPtr();
+	static auto *const TEXTPADDING = (Hyprlang::STRING const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:textpadding")->getDataStaticPtr();
+	static auto *const BORDERSIZE = (Hyprlang::INT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:bordersize")->getDataStaticPtr();
+	static auto *const BORDERCOLOR = (Hyprlang::STRING const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:bordercolor")->getDataStaticPtr();
+	static auto *const ROUNDING = (Hyprlang::INT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:rounding")->getDataStaticPtr();
+	static auto *const BLUR = (Hyprlang::INT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:blur")->getDataStaticPtr();
+	static auto *const XRAY = (Hyprlang::INT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:xray")->getDataStaticPtr();
+	static auto *const BLURA = (Hyprlang::FLOAT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:blurA")->getDataStaticPtr();
+	static auto *const MOTIONKEYS = (Hyprlang::STRING const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:motionkeys")->getDataStaticPtr();
+	static auto *const FSACTION = (Hyprlang::STRING const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:fullscreen_action")->getDataStaticPtr();
+	static auto *const ONLYSPECIAL = (Hyprlang::INT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:only_special")->getDataStaticPtr();
 
 
 	CVarList emargs(args, 0, ',');
@@ -155,16 +152,15 @@ SDispatchResult easymotionDispatch(std::string args)
 		actionDesc.borderColor.m_angle = 0;
 	}
 	actionDesc.motionKeys = *MOTIONKEYS;
-  actionDesc.blur = **BLUR;
-  actionDesc.xray = **XRAY;
-  actionDesc.blurA = **BLURA;
-  actionDesc.fullscreen_action = std::string(*FSACTION);
-  actionDesc.only_special = **ONLYSPECIAL;
+	actionDesc.blur = **BLUR;
+	actionDesc.xray = **XRAY;
+	actionDesc.blurA = **BLURA;
+	actionDesc.fullscreen_action = std::string(*FSACTION);
+	actionDesc.only_special = **ONLYSPECIAL;
 
 
 	for(size_t i = 0; i < emargs.size(); i++)
 	{
-
 		CVarList kv(emargs[i], 2, ':');
 		if (kv[0] == "action") {
 			actionDesc.commandString = kv[1];
@@ -192,36 +188,36 @@ SDispatchResult easymotionDispatch(std::string args)
 				actionDesc.borderColor.m_angle = 0;
 			}
 		} else if (kv[0] == "motionkeys") {
-				actionDesc.motionKeys = kv[1];
-    } else if (kv[0] == "blur") {
-      actionDesc.blur = configStringToInt(kv[1]).value_or(1);
-    } else if (kv[0] == "xray") {
-      actionDesc.xray = configStringToInt(kv[1]).value_or(1);
-    } else if (kv[0] == "blurA") {
-      try {
-        actionDesc.blurA = std::stof(kv[1]);
-      } catch (const std::invalid_argument& ia) {
-        actionDesc.blurA = 1.0f;
-      }
+			actionDesc.motionKeys = kv[1];
+		} else if (kv[0] == "blur") {
+			actionDesc.blur = configStringToInt(kv[1]).value_or(1);
+		} else if (kv[0] == "xray") {
+			actionDesc.xray = configStringToInt(kv[1]).value_or(1);
+		} else if (kv[0] == "blurA") {
+			try {
+				actionDesc.blurA = std::stof(kv[1]);
+			} catch (const std::invalid_argument& ia) {
+				actionDesc.blurA = 1.0f;
+			}
 		} else if (kv[0] == "fullscreen_action") {
-      actionDesc.fullscreen_action = kv[1];
-    } else if (kv[0] == "only_special") {
-      actionDesc.only_special = configStringToInt(kv[1]).value_or(1);
-    }
+			actionDesc.fullscreen_action = kv[1];
+		} else if (kv[0] == "only_special") {
+			actionDesc.only_special = configStringToInt(kv[1]).value_or(1);
+		}
 	}
 
-  std::transform(actionDesc.fullscreen_action.begin(), actionDesc.fullscreen_action.end(), actionDesc.fullscreen_action.begin(), tolower);
+	std::transform(actionDesc.fullscreen_action.begin(), actionDesc.fullscreen_action.end(), actionDesc.fullscreen_action.begin(), tolower);
 	int key_idx = 0;
 
 	for (auto &w : g_pCompositor->m_windows) {
 		for (auto &m : g_pCompositor->m_monitors) {
 			if (w->m_workspace == m->m_activeWorkspace || m->m_activeSpecialWorkspace == w->m_workspace) {
-					if (w->isHidden() || !w->m_isMapped || w->m_fadingOut)
-						continue;
-          if (m->m_activeSpecialWorkspace && w->m_workspace != m->m_activeSpecialWorkspace && actionDesc.only_special)
-            continue;
-					std::string lstr = actionDesc.motionKeys.substr(key_idx++, 1);
-					addLabelToWindow(w, &actionDesc, lstr);
+				if (w->isHidden() || !w->m_isMapped || w->m_fadingOut)
+					continue;
+				if (m->m_activeSpecialWorkspace && w->m_workspace != m->m_activeSpecialWorkspace && actionDesc.only_special)
+					continue;
+				std::string lstr = actionDesc.motionKeys.substr(key_idx++, 1);
+				addLabelToWindow(w, &actionDesc, lstr);
 			}
 		}
 	}
@@ -229,11 +225,10 @@ SDispatchResult easymotionDispatch(std::string args)
 	if (!g_pGlobalState->motionLabels.empty())
 		HyprlandAPI::invokeHyprctlCommand("dispatch", "submap __easymotionsubmap__");
 
-  return {};
+	return {};
 }
-	
-bool oneasymotionKeypress(void *self, std::any data) {
 
+bool oneasymotionKeypress(void *self, std::any data) {
 	if (g_pGlobalState->motionLabels.empty()) return false;
 
 	auto map = std::any_cast<std::unordered_map<std::string, std::any>>(data);
@@ -262,39 +257,38 @@ bool oneasymotionKeypress(void *self, std::any data) {
 	return false;
 }
 
-
 APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
-    PHANDLE = handle;
+	PHANDLE = handle;
 
-		HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:textsize", Hyprlang::INT{15});
+	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:textsize", Hyprlang::INT{15});
 
-		HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:textcolor", Hyprlang::INT{configStringToInt("rgba(ffffffff)").value_or(0xffffffff)});
-		HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:bgcolor", Hyprlang::INT{configStringToInt("rgba(000000ff)").value_or(0xff)});
-		HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:textfont", Hyprlang::STRING{"Sans"});
-		HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:textpadding", Hyprlang::STRING{"0"});
-		HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:bordersize", Hyprlang::INT{0});
-		HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:bordercolor", Hyprlang::STRING{"rgba(ffffffff)"});
-		HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:rounding", Hyprlang::INT{0});
-		HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:blur", Hyprlang::INT{0});
-		HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:blurA", Hyprlang::FLOAT{1.0f});
-		HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:xray", Hyprlang::INT{0});
-		HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:motionkeys", Hyprlang::STRING{"abcdefghijklmnopqrstuvwxyz1234567890"});
-		HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:fullscreen_action", Hyprlang::STRING{"none"});
-		HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:only_special", Hyprlang::INT{1});
+	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:textcolor", Hyprlang::INT{configStringToInt("rgba(ffffffff)").value_or(0xffffffff)});
+	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:bgcolor", Hyprlang::INT{configStringToInt("rgba(000000ff)").value_or(0xff)});
+	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:textfont", Hyprlang::STRING{"Sans"});
+	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:textpadding", Hyprlang::STRING{"0"});
+	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:bordersize", Hyprlang::INT{0});
+	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:bordercolor", Hyprlang::STRING{"rgba(ffffffff)"});
+	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:rounding", Hyprlang::INT{0});
+	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:blur", Hyprlang::INT{0});
+	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:blurA", Hyprlang::FLOAT{1.0f});
+	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:xray", Hyprlang::INT{0});
+	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:motionkeys", Hyprlang::STRING{"abcdefghijklmnopqrstuvwxyz1234567890"});
+	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:fullscreen_action", Hyprlang::STRING{"none"});
+	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:only_special", Hyprlang::INT{1});
 
 
-		g_pGlobalState = makeUnique<SGlobalState>();
-		HyprlandAPI::addDispatcherV2(PHANDLE, "easymotion", easymotionDispatch);
-		HyprlandAPI::addDispatcherV2(PHANDLE, "easymotionaction", easymotionActionDispatch);
-		HyprlandAPI::addDispatcherV2(PHANDLE, "easymotionexit", easymotionExitDispatch);
-		static auto KPHOOK = HyprlandAPI::registerCallbackDynamic(PHANDLE, "keyPress", [&](void *self, SCallbackInfo &info, std::any data) {
-			info.cancelled = oneasymotionKeypress(self, data);
+	g_pGlobalState = makeUnique<SGlobalState>();
+	HyprlandAPI::addDispatcherV2(PHANDLE, "easymotion", easymotionDispatch);
+	HyprlandAPI::addDispatcherV2(PHANDLE, "easymotionaction", easymotionActionDispatch);
+	HyprlandAPI::addDispatcherV2(PHANDLE, "easymotionexit", easymotionExitDispatch);
+	static auto KPHOOK = HyprlandAPI::registerCallbackDynamic(PHANDLE, "keyPress", [&](void *self, SCallbackInfo &info, std::any data) {
+		info.cancelled = oneasymotionKeypress(self, data);
 	});
-	  static auto CRHOOK = HyprlandAPI::registerCallbackDynamic(PHANDLE, "configReloaded", [&](void *self, SCallbackInfo&, std::any data) {addEasyMotionKeybinds();});
-    HyprlandAPI::reloadConfig();
+	static auto CRHOOK = HyprlandAPI::registerCallbackDynamic(PHANDLE, "configReloaded", [&](void *self, SCallbackInfo&, std::any data) {addEasyMotionKeybinds();});
+	HyprlandAPI::reloadConfig();
 
 
-    return {"hypreasymotion", "Easymotion navigation", "Zakk", "1.0"};
+	return {"hypreasymotion", "Easymotion navigation", "Zakk", "1.0"};
 }
 
 APICALL EXPORT void PLUGIN_EXIT() {


### PR DESCRIPTION
Adds support for displaying a different on-screen label than the actual input used to select it. Useful for stuff like showing uppercase letters while still selecting them with lowercase key presses.

**NOTE:**
* This relies on https://github.com/zakk4223/hyprland-easymotion/pull/23 getting merged
* This pull-request contains significant white-space changes, mostly for my own sanity. I could revert it upon request