### PR TITLE
Fix compatibility with Hyprland 0.56.0

### DIFF
--- a/easymotionDeco.cpp
+++ b/easymotionDeco.cpp
@@ -58,7 +58,7 @@ std::string CHyprEasyLabel::getDisplayName() {
 }
 
 void CHyprEasyLabel::renderMotionString(Vector2D& bufferSize, const float scale) {
-	m_tTextTex = makeShared<CGLTexture>();
+	m_tTextTex = makeShared<Render::GL::CGLTexture>();
 	int textSize = m_iTextSize;
 	const auto scaledSize = textSize * scale;
 	const auto textColor = CHyprColor(m_cTextColor);
@@ -115,9 +115,6 @@ void CHyprEasyLabel::renderMotionString(Vector2D& bufferSize, const float scale)
 	cairo_destroy(LAYOUTCAIRO);
 	cairo_destroy(CAIRO);
 	cairo_surface_destroy(CAIROSURFACE);
-
-	//renderText doesn't use ink_rect, but logical_rect. Makes the rectangle too tall
-	//m_tTextTex = g_pHyprOpenGL->renderText(m_szLabel, m_cTextColor, textSize, false, m_szTextFont, bufferSize.x-2);
 }
 
 
@@ -132,7 +129,6 @@ void CHyprEasyLabel::draw(PHLMONITOR pMonitor, float const &a) {
 	const auto WORKSPACEOFFSET = PWORKSPACE && !PWINDOW->m_pinned ? PWORKSPACE->m_renderOffset->value() : Vector2D();
 	const auto DECOBOX = assignedBoxGlobal();
 	const auto BARBUF = DECOBOX.size() * pMonitor->m_scale;
-	//CBox       motionBox = {DECOBOX.x - pMonitor->vecPosition.x, DECOBOX.y - pMonitor->vecPosition.y, DECOBOX.w,
 	
 	auto TEXTBUF = DECOBOX.size();
 
@@ -158,8 +154,7 @@ void CHyprEasyLabel::draw(PHLMONITOR pMonitor, float const &a) {
 	rectData.round = m_iRounding * pMonitor->m_scale;
 	rectData.roundingPower = 2.0;
 
-
-	g_pHyprRenderer->m_renderPass.add(makeUnique<CRectPassElement>(rectData));
+	g_pHyprRenderer->addPassElement(makeUnique<CRectPassElement>(rectData));
 	if (m_iBorderSize) {
 		CBox       borderBox = {DECOBOX.x, DECOBOX.y, static_cast<double>(layoutWidth), static_cast<double>(layoutHeight)};
 		borderBox.translate(pMonitor->m_position*-1).scale(pMonitor->m_scale).round();
@@ -171,8 +166,7 @@ void CHyprEasyLabel::draw(PHLMONITOR pMonitor, float const &a) {
 			borderData.roundingPower = 2.0;
 			borderData.borderSize = m_iBorderSize;
 			borderData.a = a;
-			g_pHyprRenderer->m_renderPass.add(makeUnique<CBorderPassElement>(borderData));
-			//g_pHyprOpenGL->renderBorder(borderBox, m_cBorderGradient, scaledRounding, m_iBorderSize * pMonitor->scale, a);
+			g_pHyprRenderer->addPassElement(makeUnique<CBorderPassElement>(borderData));
 		}
 	}
 	
@@ -181,8 +175,7 @@ void CHyprEasyLabel::draw(PHLMONITOR pMonitor, float const &a) {
 	texData.tex = m_tTextTex;
 	texData.box = motionBox;
 
-
-	g_pHyprRenderer->m_renderPass.add(makeUnique<CTexPassElement>(texData));
+	g_pHyprRenderer->addPassElement(makeUnique<CTexPassElement>(texData));
 }
 
 eDecorationType CHyprEasyLabel::getDecorationType() {
@@ -212,11 +205,11 @@ CBox CHyprEasyLabel::assignedBoxGlobal() {
 	const auto PWINDOW = m_pWindow.lock();
 	double boxHeight, boxWidth;
 	double boxSize;
-	boxHeight = PWINDOW->m_realSize->value().y * 0.10;
-	boxWidth = PWINDOW->m_realSize->value().x * 0.10;
+	boxHeight = PWINDOW->size(Desktop::View::IGeometric::GEOMETRIC_CURRENT).y * 0.10;
+	boxWidth = PWINDOW->size(Desktop::View::IGeometric::GEOMETRIC_CURRENT).x * 0.10;
 	boxSize = std::min(boxHeight, boxWidth);
-	double boxX = PWINDOW->m_realPosition->value().x + (PWINDOW->m_realSize->value().x-boxSize)/2;
-	double boxY = PWINDOW->m_realPosition->value().y + (PWINDOW->m_realSize->value().y-boxSize)/2;
+	double boxX = PWINDOW->position(Desktop::View::IGeometric::GEOMETRIC_CURRENT).x + (PWINDOW->size(Desktop::View::IGeometric::GEOMETRIC_CURRENT).x-boxSize)/2;
+	double boxY = PWINDOW->position(Desktop::View::IGeometric::GEOMETRIC_CURRENT).y + (PWINDOW->size(Desktop::View::IGeometric::GEOMETRIC_CURRENT).y-boxSize)/2;
 	CBox box = {boxX, boxY, boxSize, boxSize};
 
 	const auto PWORKSPACE      = PWINDOW->m_workspace;

--- a/easymotionDeco.hpp
+++ b/easymotionDeco.hpp
@@ -8,6 +8,7 @@
 #include <hyprland/src/devices/IKeyboard.hpp>
 #include <hyprland/src/desktop/Workspace.hpp>
 #include <hyprland/src/render/gl/GLTexture.hpp>
+#include <hyprland/src/managers/fullscreen/FullscreenController.hpp>
 #include "globals.hpp"
 
 class CHyprEasyLabel : public IHyprWindowDecoration {
@@ -57,10 +58,7 @@ class CHyprEasyLabel : public IHyprWindowDecoration {
 		int                                m_iBorderSize;
 		Config::CGradientValueData	   m_cBorderGradient;
 		WP<CHyprEasyLabel>                 m_self;
-		eFullscreenMode                    m_origFSMode;
-
-
-
+		Fullscreen::eFullscreenMode        m_origFSMode;
 
 
 	private:
@@ -70,11 +68,11 @@ class CHyprEasyLabel : public IHyprWindowDecoration {
 
 		PHLWINDOWREF             m_pWindow;
 
-		SP<CGLTexture>           m_tTextTex;
+		SP<Render::GL::CGLTexture>           m_tTextTex;
 
 		bool                     m_bWindowSizeChanged = false;
 
-		void                     renderText(CGLTexture& out, const std::string& text, const CHyprColor& color, const Vector2D& bufferSize, const float scale, const int fontSize);
+		void                     renderText(Render::GL::CGLTexture& out, const std::string& text, const CHyprColor& color, const Vector2D& bufferSize, const float scale, const int fontSize);
 		CBox                     assignedBoxGlobal();
 		void                     renderMotionString(Vector2D& bufferSize, const float scale);
 

--- a/main.cpp
+++ b/main.cpp
@@ -5,6 +5,7 @@
 
 #include <any>
 #include <ranges>
+#include <cmath>
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/desktop/view/Window.hpp>
 #include <hyprland/src/config/ConfigManager.hpp>
@@ -12,7 +13,16 @@
 #include <hyprland/src/managers/input/InputManager.hpp>
 #include <hyprland/src/event/EventBus.hpp>
 #include <hyprland/src/debug/log/Logger.hpp>
+#include <hyprland/src/managers/fullscreen/FullscreenController.hpp>
+#include <hyprland/src/desktop/state/WindowState.hpp>
+#include <hyprland/src/state/MonitorState.hpp>
+#include <hyprland/src/config/values/ConfigValues.hpp>
+#include <hyprland/src/config/values/types/IntValue.hpp>
+#include <hyprland/src/config/values/types/FloatValue.hpp>
+#include <hyprland/src/config/values/types/StringValue.hpp>
+#include <hyprland/src/config/shared/parserUtils/ParserUtils.hpp>
 #include <hyprutils/string/VarList.hpp>
+#include <hyprutils/string/VarList2.hpp>
 #include <strings.h>
 
 #include "easymotionDeco.hpp"
@@ -20,7 +30,23 @@
 
 using namespace Hyprutils::String;
 
-// Do NOT change this function.
+// Plugin config value pointers
+inline SP<Config::Values::CIntValue>    g_textSize;
+inline SP<Config::Values::CIntValue>    g_textColor;
+inline SP<Config::Values::CIntValue>    g_bgColor;
+inline SP<Config::Values::CStringValue> g_textFont;
+inline SP<Config::Values::CStringValue> g_textPadding;
+inline SP<Config::Values::CIntValue>    g_borderSize;
+inline SP<Config::Values::CStringValue> g_borderColor;
+inline SP<Config::Values::CIntValue>    g_rounding;
+inline SP<Config::Values::CIntValue>    g_blur;
+inline SP<Config::Values::CIntValue>    g_xray;
+inline SP<Config::Values::CFloatValue>  g_blurA;
+inline SP<Config::Values::CStringValue> g_motionKeys;
+inline SP<Config::Values::CStringValue> g_motionLabels;
+inline SP<Config::Values::CStringValue> g_fullscreenAction;
+inline SP<Config::Values::CIntValue>    g_onlySpecial;
+
 APICALL EXPORT std::string PLUGIN_API_VERSION() {
 	return HYPRLAND_API_VERSION;
 }
@@ -29,8 +55,8 @@ APICALL EXPORT std::string PLUGIN_API_VERSION() {
 SDispatchResult easymotionExitDispatch(std::string args)
 {
 	for (auto &ml : g_pGlobalState->motionLabels | std::ranges::views::reverse) {
-		if (ml->m_origFSMode != ml->getOwner()->m_fullscreenState.internal)
-			g_pCompositor->setWindowFullscreenInternal(ml->getOwner(), ml->m_origFSMode);
+		if (ml->m_origFSMode != Fullscreen::controller()->getFullscreenModes(ml->getOwner()).internal)
+			Fullscreen::controller()->setFullscreenMode(ml->getOwner(), ml->m_origFSMode);
 		ml->getOwner()->removeWindowDeco(ml.get());
 	}
 	HyprlandAPI::invokeHyprctlCommand("dispatch", "submap reset");
@@ -56,7 +82,6 @@ SDispatchResult easymotionActionDispatch(std::string args)
 void addEasyMotionKeybinds()
 {
 	g_pKeybindManager->addKeybind(SKeybind{"escape", {}, 0, 0, 0, {}, "easymotionexit", "", 0, "__easymotionsubmap__", "", "", 0, 0, 0, 0, 0, 0, 0, 0});
-	//catchall
 	g_pKeybindManager->addKeybind(SKeybind{"", {}, 0, 1, 0, {}, "", "", 0, "__easymotionsubmap__", "", "", 0, 0, 0, 0, 0, 0, 0, 0});
 }
 
@@ -69,14 +94,14 @@ void addLabelToWindow(PHLWINDOW window, SMotionActionDesc *actionDesc, std::stri
 	g_pGlobalState->motionLabels.emplace_back(motionlabel);
 	motionlabel->m_self = motionlabel;
 	motionlabel->draw(window->m_monitor.lock(), 1.0);
-	motionlabel->m_origFSMode = window->m_fullscreenState.internal;
-	if ((motionlabel->m_origFSMode != eFullscreenMode::FSMODE_NONE) && (actionDesc->fullscreen_action != "none"))
+	motionlabel->m_origFSMode = Fullscreen::controller()->getFullscreenModes(window).internal;
+	if ((motionlabel->m_origFSMode != Fullscreen::FSMODE_NONE) && (actionDesc->fullscreen_action != "none"))
 	{
 		if (actionDesc->fullscreen_action == "maximize")
 		{
-			g_pCompositor->setWindowFullscreenInternal(window, FSMODE_MAXIMIZED);
+			Fullscreen::controller()->setFullscreenMode(window, Fullscreen::FSMODE_MAXIMIZED);
 		} else if (actionDesc->fullscreen_action == "toggle") {
-			g_pCompositor->setWindowFullscreenInternal(window, FSMODE_NONE);
+			Fullscreen::controller()->setFullscreenMode(window, Fullscreen::FSMODE_NONE);
 		}
 	}
 	HyprlandAPI::addWindowDecoration(PHANDLE, window, std::move(motionlabel));
@@ -92,9 +117,8 @@ static bool parseBorderGradient(std::string VALUE, Config::CGradientValueData *D
 
 	for (auto& var : varlist) {
 		if (var.find("deg") != std::string::npos) {
-			// last arg
 			try {
-				DATA->m_angle = std::stoi(var.substr(0, var.find("deg"))) * (PI / 180.0); // radians
+				DATA->m_angle = std::stoi(var.substr(0, var.find("deg"))) * (M_PI / 180.0);
 			} catch (...) {
         		Log::logger->log(Log::WARN, "Error parsing gradient {}", V);
 				return false;
@@ -109,7 +133,7 @@ static bool parseBorderGradient(std::string VALUE, Config::CGradientValueData *D
 		}
 
 		try {
-			DATA->m_colors.push_back(CHyprColor(configStringToInt(var).value_or(0)));
+			DATA->m_colors.push_back(CHyprColor(Config::ParserUtils::parseColor(var).value_or(0)));
 		} catch (std::exception& e) {
 			Log::logger->log(Log::WARN, "Error parsing gradient {}", V);
 		}
@@ -117,56 +141,50 @@ static bool parseBorderGradient(std::string VALUE, Config::CGradientValueData *D
 
 	if (DATA->m_colors.size() == 0) {
 		Log::logger->log(Log::WARN, "Error parsing gradient {}", V);
-		DATA->m_colors.push_back(0); // transparent
+		DATA->m_colors.push_back(0);
 	}
 
 	DATA->updateColorsOk();
 	return true;
 }
 
+static int configGetInt(SP<Config::Values::CIntValue> val) {
+    return (int)(val->value());
+}
+
+static std::string configGetString(SP<Config::Values::CStringValue> val) {
+    return val->value();
+}
+
+static float configGetFloat(SP<Config::Values::CFloatValue> val) {
+    return val->value();
+}
+
 SDispatchResult easymotionDispatch(std::string args)
 {
-	static auto *const TEXTSIZE = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:textsize")->getDataStaticPtr();
-
-	static auto *const TEXTCOLOR = (Hyprlang::INT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:textcolor")->getDataStaticPtr();
-	static auto *const BGCOLOR = (Hyprlang::INT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:bgcolor")->getDataStaticPtr();
-	static auto *const TEXTFONT = (Hyprlang::STRING const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:textfont")->getDataStaticPtr();
-	static auto *const TEXTPADDING = (Hyprlang::STRING const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:textpadding")->getDataStaticPtr();
-	static auto *const BORDERSIZE = (Hyprlang::INT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:bordersize")->getDataStaticPtr();
-	static auto *const BORDERCOLOR = (Hyprlang::STRING const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:bordercolor")->getDataStaticPtr();
-	static auto *const ROUNDING = (Hyprlang::INT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:rounding")->getDataStaticPtr();
-	static auto *const BLUR = (Hyprlang::INT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:blur")->getDataStaticPtr();
-	static auto *const XRAY = (Hyprlang::INT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:xray")->getDataStaticPtr();
-	static auto *const BLURA = (Hyprlang::FLOAT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:blurA")->getDataStaticPtr();
-	static auto *const MOTIONKEYS = (Hyprlang::STRING const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:motionkeys")->getDataStaticPtr();
-	static auto *const MOTIONLABELS = (Hyprlang::STRING const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:motionlabels")->getDataStaticPtr();
-	static auto *const FSACTION = (Hyprlang::STRING const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:fullscreen_action")->getDataStaticPtr();
-	static auto *const ONLYSPECIAL = (Hyprlang::INT* const *)HyprlandAPI::getConfigValue(PHANDLE, "plugin:easymotion:only_special")->getDataStaticPtr();
-
-
-	CVarList emargs(args, 0, ',');
 	SMotionActionDesc actionDesc;
 
-	actionDesc.textSize = **TEXTSIZE;
-	actionDesc.textColor = **TEXTCOLOR;
-	actionDesc.backgroundColor = **BGCOLOR;
-	actionDesc.textFont = *TEXTFONT;
-	CVarList2 cpadding = CVarList2(*TEXTPADDING);
+	actionDesc.textSize = configGetInt(g_textSize);
+	actionDesc.textColor = CHyprColor(configGetInt(g_textColor));
+	actionDesc.backgroundColor = CHyprColor(configGetInt(g_bgColor));
+	actionDesc.textFont = configGetString(g_textFont);
+	CVarList2 cpadding = CVarList2(configGetString(g_textPadding));
 	actionDesc.boxPadding.parseGapData(cpadding);
-	actionDesc.rounding = **ROUNDING;
-	actionDesc.borderSize = **BORDERSIZE;
-	if(!parseBorderGradient(*BORDERCOLOR, &actionDesc.borderColor)) {
+	actionDesc.rounding = configGetInt(g_rounding);
+	actionDesc.borderSize = configGetInt(g_borderSize);
+	if(!parseBorderGradient(configGetString(g_borderColor), &actionDesc.borderColor)) {
 		actionDesc.borderColor.m_colors.clear();
 		actionDesc.borderColor.m_angle = 0;
 	}
-	actionDesc.motionKeys = *MOTIONKEYS;
-	actionDesc.motionLabels = *MOTIONLABELS;
-	actionDesc.blur = **BLUR;
-	actionDesc.xray = **XRAY;
-	actionDesc.blurA = **BLURA;
-	actionDesc.fullscreen_action = std::string(*FSACTION);
-	actionDesc.only_special = **ONLYSPECIAL;
+	actionDesc.motionKeys = configGetString(g_motionKeys);
+	actionDesc.motionLabels = configGetString(g_motionLabels);
+	actionDesc.blur = configGetInt(g_blur);
+	actionDesc.xray = configGetInt(g_xray);
+	actionDesc.blurA = configGetFloat(g_blurA);
+	actionDesc.fullscreen_action = std::string(configGetString(g_fullscreenAction));
+	actionDesc.only_special = configGetInt(g_onlySpecial);
 
+	CVarList emargs(args, 0, ',');
 
 	for(size_t i = 0; i < emargs.size(); i++)
 	{
@@ -174,20 +192,20 @@ SDispatchResult easymotionDispatch(std::string args)
 		if (kv[0] == "action") {
 			actionDesc.commandString = kv[1];
 		} else if (kv[0] == "textsize") {
-			actionDesc.textSize = configStringToInt(kv[1]).value_or(15);
+			actionDesc.textSize = Config::ParserUtils::parseInt(kv[1]).value_or(15);
 		} else if (kv[0] == "textcolor") {
-			actionDesc.textColor = CHyprColor(configStringToInt(kv[1]).value_or(0xffffffff));
+			actionDesc.textColor = CHyprColor(Config::ParserUtils::parseColor(kv[1]).value_or(0xffffffff));
 		} else if (kv[0] == "bgcolor") {
-			actionDesc.backgroundColor = CHyprColor(configStringToInt(kv[1]).value_or(0));
+			actionDesc.backgroundColor = CHyprColor(Config::ParserUtils::parseColor(kv[1]).value_or(0));
 		} else if (kv[0] == "textfont") {
 			actionDesc.textFont = kv[1];
 		} else if (kv[0] == "textpadding") {
 			CVarList2 padVars = CVarList2(kv[1], 0, 's');
 			actionDesc.boxPadding.parseGapData(padVars);
 		} else if (kv[0] == "rounding") {
-			actionDesc.rounding = configStringToInt(kv[1]).value_or(0);
+			actionDesc.rounding = Config::ParserUtils::parseInt(kv[1]).value_or(0);
 		} else if (kv[0] == "bordersize") {
-			actionDesc.borderSize = configStringToInt(kv[1]).value_or(0);
+			actionDesc.borderSize = Config::ParserUtils::parseInt(kv[1]).value_or(0);
 		} else if (kv[0] == "bordercolor") {
 			CVarList varlist(kv[1], 0, 's');
 			actionDesc.borderColor.m_colors.clear();
@@ -201,9 +219,9 @@ SDispatchResult easymotionDispatch(std::string args)
 		} else if (kv[0] == "motionlabels") {
 			actionDesc.motionLabels = kv[1];
 		} else if (kv[0] == "blur") {
-			actionDesc.blur = configStringToInt(kv[1]).value_or(1);
+			actionDesc.blur = Config::ParserUtils::parseInt(kv[1]).value_or(1);
 		} else if (kv[0] == "xray") {
-			actionDesc.xray = configStringToInt(kv[1]).value_or(1);
+			actionDesc.xray = Config::ParserUtils::parseInt(kv[1]).value_or(1);
 		} else if (kv[0] == "blurA") {
 			try {
 				actionDesc.blurA = std::stof(kv[1]);
@@ -213,24 +231,23 @@ SDispatchResult easymotionDispatch(std::string args)
 		} else if (kv[0] == "fullscreen_action") {
 			actionDesc.fullscreen_action = kv[1];
 		} else if (kv[0] == "only_special") {
-			actionDesc.only_special = configStringToInt(kv[1]).value_or(1);
+			actionDesc.only_special = Config::ParserUtils::parseInt(kv[1]).value_or(1);
 		}
 	}
 
 	if (actionDesc.motionLabels.size() == 0) {
 		actionDesc.motionLabels = actionDesc.motionKeys;
 	} else if (actionDesc.motionLabels.size() != actionDesc.motionKeys.size()) {
-		//TODO: add a warning here
 		actionDesc.motionLabels = actionDesc.motionKeys;
 	}
 
 	std::transform(actionDesc.fullscreen_action.begin(), actionDesc.fullscreen_action.end(), actionDesc.fullscreen_action.begin(), tolower);
 	int key_idx = 0;
 
-	for (auto &w : g_pCompositor->m_windows) {
-		for (auto &m : g_pCompositor->m_monitors) {
+	for (auto &w : Desktop::viewState()->windows()) {
+		for (auto &m : State::monitorState()->monitors()) {
 			if (w->m_workspace == m->m_activeWorkspace || m->m_activeSpecialWorkspace == w->m_workspace) {
-				if (w->isHidden() || !w->m_isMapped || w->m_fadingOut)
+				if (w->isHidden() || !w->m_isMapped)
 					continue;
 				if (m->m_activeSpecialWorkspace && w->m_workspace != m->m_activeSpecialWorkspace && actionDesc.only_special)
 					continue;
@@ -277,22 +294,83 @@ bool oneasymotionKeypress(const IKeyboard::SKeyEvent& ev) {
 APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle) {
 	PHANDLE = handle;
 
-	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:textsize", Hyprlang::INT{15});
+	g_textSize = makeShared<Config::Values::CIntValue>(
+	    "plugin:easymotion:textsize", "Text size", 15,
+	    Config::Values::SIntValueOptions{});
+	HyprlandAPI::addConfigValueV2(PHANDLE, g_textSize);
 
-	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:textcolor", Hyprlang::INT{configStringToInt("rgba(ffffffff)").value_or(0xffffffff)});
-	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:bgcolor", Hyprlang::INT{configStringToInt("rgba(000000ff)").value_or(0xff)});
-	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:textfont", Hyprlang::STRING{"Sans"});
-	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:textpadding", Hyprlang::STRING{"0"});
-	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:bordersize", Hyprlang::INT{0});
-	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:bordercolor", Hyprlang::STRING{"rgba(ffffffff)"});
-	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:rounding", Hyprlang::INT{0});
-	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:blur", Hyprlang::INT{0});
-	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:blurA", Hyprlang::FLOAT{1.0f});
-	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:xray", Hyprlang::INT{0});
-	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:motionkeys", Hyprlang::STRING{"abcdefghijklmnopqrstuvwxyz1234567890"});
-	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:motionlabels", Hyprlang::STRING{""});
-	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:fullscreen_action", Hyprlang::STRING{"none"});
-	HyprlandAPI::addConfigValue(PHANDLE, "plugin:easymotion:only_special", Hyprlang::INT{1});
+	g_textColor = makeShared<Config::Values::CIntValue>(
+	    "plugin:easymotion:textcolor", "Text color",
+	    Config::ParserUtils::parseColor("rgba(ffffffff)").value_or(0xffffffff),
+	    Config::Values::SIntValueOptions{});
+	HyprlandAPI::addConfigValueV2(PHANDLE, g_textColor);
+
+	g_bgColor = makeShared<Config::Values::CIntValue>(
+	    "plugin:easymotion:bgcolor", "Background color",
+	    Config::ParserUtils::parseColor("rgba(000000ff)").value_or(0xff),
+	    Config::Values::SIntValueOptions{});
+	HyprlandAPI::addConfigValueV2(PHANDLE, g_bgColor);
+
+	g_textFont = makeShared<Config::Values::CStringValue>(
+	    "plugin:easymotion:textfont", "Text font", "Sans",
+	    Config::Values::SStringValueOptions{});
+	HyprlandAPI::addConfigValueV2(PHANDLE, g_textFont);
+
+	g_textPadding = makeShared<Config::Values::CStringValue>(
+	    "plugin:easymotion:textpadding", "Text padding", "0",
+	    Config::Values::SStringValueOptions{});
+	HyprlandAPI::addConfigValueV2(PHANDLE, g_textPadding);
+
+	g_borderSize = makeShared<Config::Values::CIntValue>(
+	    "plugin:easymotion:bordersize", "Border size", 0,
+	    Config::Values::SIntValueOptions{});
+	HyprlandAPI::addConfigValueV2(PHANDLE, g_borderSize);
+
+	g_borderColor = makeShared<Config::Values::CStringValue>(
+	    "plugin:easymotion:bordercolor", "Border color", "rgba(ffffffff)",
+	    Config::Values::SStringValueOptions{});
+	HyprlandAPI::addConfigValueV2(PHANDLE, g_borderColor);
+
+	g_rounding = makeShared<Config::Values::CIntValue>(
+	    "plugin:easymotion:rounding", "Rounding", 0,
+	    Config::Values::SIntValueOptions{});
+	HyprlandAPI::addConfigValueV2(PHANDLE, g_rounding);
+
+	g_blur = makeShared<Config::Values::CIntValue>(
+	    "plugin:easymotion:blur", "Blur", 0,
+	    Config::Values::SIntValueOptions{});
+	HyprlandAPI::addConfigValueV2(PHANDLE, g_blur);
+
+	g_blurA = makeShared<Config::Values::CFloatValue>(
+	    "plugin:easymotion:blurA", "Blur amount", 1.0f,
+	    Config::Values::SFloatValueOptions{});
+	HyprlandAPI::addConfigValueV2(PHANDLE, g_blurA);
+
+	g_xray = makeShared<Config::Values::CIntValue>(
+	    "plugin:easymotion:xray", "Xray", 0,
+	    Config::Values::SIntValueOptions{});
+	HyprlandAPI::addConfigValueV2(PHANDLE, g_xray);
+
+	g_motionKeys = makeShared<Config::Values::CStringValue>(
+	    "plugin:easymotion:motionkeys", "Motion keys",
+	    "abcdefghijklmnopqrstuvwxyz1234567890",
+	    Config::Values::SStringValueOptions{});
+	HyprlandAPI::addConfigValueV2(PHANDLE, g_motionKeys);
+
+	g_motionLabels = makeShared<Config::Values::CStringValue>(
+	    "plugin:easymotion:motionlabels", "Motion labels", "",
+	    Config::Values::SStringValueOptions{});
+	HyprlandAPI::addConfigValueV2(PHANDLE, g_motionLabels);
+
+	g_fullscreenAction = makeShared<Config::Values::CStringValue>(
+	    "plugin:easymotion:fullscreen_action", "Fullscreen action", "none",
+	    Config::Values::SStringValueOptions{});
+	HyprlandAPI::addConfigValueV2(PHANDLE, g_fullscreenAction);
+
+	g_onlySpecial = makeShared<Config::Values::CIntValue>(
+	    "plugin:easymotion:only_special", "Only special workspace", 1,
+	    Config::Values::SIntValueOptions{});
+	HyprlandAPI::addConfigValueV2(PHANDLE, g_onlySpecial);
 
 
 	g_pGlobalState = makeUnique<SGlobalState>();


### PR DESCRIPTION
Actually this fix totally vibecoded, but it works, so you can use it on your own risk, if you need easymotion to work on hyprland 0.56
closes #50 

## Summary

Updates all API calls to be compatible with Hyprland 0.56.0.

## Changes

- **Config**: Migrated from deprecated `addConfigValue`/`getConfigValue` to `addConfigValueV2` with typed value objects (`CIntValue`, `CStringValue`, `CFloatValue`)
- **Fullscreen**: Replaced `CCompositor::setWindowFullscreenInternal` and `m_fullscreenState` with `Fullscreen::controller()->setFullscreenMode()`/`getFullscreenModes()`
- **Window/Monitor access**: Changed `g_pCompositor->m_windows`/`m_monitors` to `Desktop::viewState()->windows()`/`State::monitorState()->monitors()`
- **Window geometry**: Changed `m_realPosition`/`m_realSize` to `position(IGeometric::GEOMETRIC_CURRENT)`/`size(...)`
- **CGLTexture**: Updated namespace to `Render::GL::CGLTexture`
- **Renderer passes**: Changed `m_renderPass.add()` to `g_pHyprRenderer->addPassElement()`
- **Parser**: Replaced `configStringToInt` with `Config::ParserUtils::parseInt`/`parseColor`
- **Constants**: Replaced `PI` with `M_PI` from \<cmath\>
- Removed references to removed `m_fadingOut` field

Tested on Hyprland 0.56.0 built from branch v0.56.0 (commit 36b2e0cfe0c6094dbc47bd42a437431315bb3087).